### PR TITLE
Fixed warnings when building with `-Wwrite-strings`

### DIFF
--- a/nimble/host/src/ble_hs_hci.c
+++ b/nimble/host/src/ble_hs_hci.c
@@ -106,7 +106,7 @@
 
 struct err_code {
     int error_code;
-    char *msg;
+    const char *msg;
 };
 
 static struct err_code err_code_list[] = {


### PR DESCRIPTION
When CONFIG_COMPILER_WARN_WRITE_STRINGS=y, the compiler emits warnings about a non-const pointer pointing to const strings. This fixes it.